### PR TITLE
Adding Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+# You can also use email addresses if you prefer.
+
+# Default reviewers
+*                     @bijujoseph


### PR DESCRIPTION
### Fixes 
Code reviews do not auto assign codeowners

### Proposed changes:
- Setting default reviewer in CODEOWNERS file

<!-- Add detailed discussion of changes here -->

### Security implications
None

### Acceptance criteria validation
Ensure PRs have reviewers auto suggested

### Requested feedback
N/A