### PR TITLE
DOCQS-774: update git issue creation workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         repo:
           - CMSgov/epcs-etl
-          - CMSgov/qpp-eligibility
     steps:
       - name: Checkout Codebase
         uses: actions/checkout@v3


### PR DESCRIPTION
### Fixes 
* Update git issue creation workflow to remove CMSgov/qpp-eligibility 

### Proposed changes:
* Update git issue creation workflow to remove CMSgov/qpp-eligibility

### Security implications
* Update git issue creation workflow to remove CMSgov/qpp-eligibility


### Acceptance criteria validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? If not, why not? -->

### Requested feedback
N/A
