### PR TITLE
[QPPELIG-4460] Migrate to OIT SonarQube

### DIFF
--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -5,7 +5,7 @@ env:
         SQ_TOKEN: "/devops/extra/sonarqube-token-eu-data"
     variables:
         SQ_PROJECT: "qpp-eu-data"
-        SQ_SOURCES: "src"
+        SQ_SOURCES: "."
         SQ_ORGANIZATION: "cmsgov"
         SQ_HOST_URL: "https://sonarqube.cloud.cms.gov"
 phases:

--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -7,6 +7,7 @@ env:
         SQ_PROJECT: "qpp-eu-data"
         SQ_SOURCES: "."
         SQ_TESTS: "tests"
+        SQ_EXCLUSIONS: "tests"
         SQ_ORGANIZATION: "cmsgov"
         SQ_HOST_URL: "https://sonarqube.cloud.cms.gov"
 phases:
@@ -30,5 +31,6 @@ phases:
                     -Dsonar.organization=${SQ_ORGANIZATION} \
                     -Dsonar.sources=${SQ_SOURCES} \
                     -Dsonar.tests=${SQ_TESTS} \
+                    -Dsonar.exclusions=${SONAR_EXCLUSIONS}
                     -Dsonar.host.url=${SQ_HOST_URL} \
                     -Dsonar.login=${SQ_TOKEN}

--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -6,6 +6,7 @@ env:
     variables:
         SQ_PROJECT: "qpp-eu-data"
         SQ_SOURCES: "."
+        SQ_TESTS: "tests"
         SQ_ORGANIZATION: "cmsgov"
         SQ_HOST_URL: "https://sonarqube.cloud.cms.gov"
 phases:
@@ -28,5 +29,6 @@ phases:
                     -Dsonar.branch.name=${BRANCH} \
                     -Dsonar.organization=${SQ_ORGANIZATION} \
                     -Dsonar.sources=${SQ_SOURCES} \
+                    -Dsonar.tests=${SQ_TESTS} \
                     -Dsonar.host.url=${SQ_HOST_URL} \
                     -Dsonar.login=${SQ_TOKEN}

--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -6,8 +6,6 @@ env:
     variables:
         SQ_PROJECT: "qpp-eu-data"
         SQ_SOURCES: "."
-        SQ_TESTS: "tests"
-        SQ_EXCLUSIONS: "tests"
         SQ_ORGANIZATION: "cmsgov"
         SQ_HOST_URL: "https://sonarqube.cloud.cms.gov"
 phases:
@@ -30,7 +28,5 @@ phases:
                     -Dsonar.branch.name=${BRANCH} \
                     -Dsonar.organization=${SQ_ORGANIZATION} \
                     -Dsonar.sources=${SQ_SOURCES} \
-                    -Dsonar.tests=${SQ_TESTS} \
-                    -Dsonar.exclusions=${SONAR_EXCLUSIONS} \
                     -Dsonar.host.url=${SQ_HOST_URL} \
                     -Dsonar.login=${SQ_TOKEN}

--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -1,0 +1,32 @@
+version: 0.2
+env:
+    shell: bash
+    parameter-store:
+        SQ_TOKEN: "/devops/extra/sonarqube-token-eu-data"
+    variables:
+        SQ_PROJECT: "qpp-eu-data"
+        SQ_SOURCES: "src"
+        SQ_ORGANIZATION: "cmsgov"
+        SQ_HOST_URL: "https://sonarqube.cloud.cms.gov"
+phases:
+    install:
+      runtime-versions:
+        java: corretto17
+    pre_build:
+        commands:
+            # Export local variables
+            - export BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/}
+            - wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-7.1.0.4889-linux-x64.zip
+            - unzip ./sonar-scanner-cli-7.1.0.4889-linux-x64.zip
+            - export PATH=$PATH:sonar-scanner-7.1.0.4889-linux-x64/bin/
+    build:
+        commands:
+            # Code quality analysis using internal SonarQube
+            - |
+                sonar-scanner \
+                    -Dsonar.projectKey=${SQ_PROJECT} \
+                    -Dsonar.branch.name=${BRANCH} \
+                    -Dsonar.organization=${SQ_ORGANIZATION} \
+                    -Dsonar.sources=${SQ_SOURCES} \
+                    -Dsonar.host.url=${SQ_HOST_URL} \
+                    -Dsonar.login=${SQ_TOKEN}

--- a/infrastructure/buildspec/ci.yaml
+++ b/infrastructure/buildspec/ci.yaml
@@ -31,6 +31,6 @@ phases:
                     -Dsonar.organization=${SQ_ORGANIZATION} \
                     -Dsonar.sources=${SQ_SOURCES} \
                     -Dsonar.tests=${SQ_TESTS} \
-                    -Dsonar.exclusions=${SONAR_EXCLUSIONS}
+                    -Dsonar.exclusions=${SONAR_EXCLUSIONS} \
                     -Dsonar.host.url=${SQ_HOST_URL} \
                     -Dsonar.login=${SQ_TOKEN}


### PR DESCRIPTION
### Fixes 
<!-- describe the problem being solved here -->
QPP is migrating from SonarQube Cloud to OIT SonarQube internal host. Because the new instance is behind the firewall a GH webhook will not work. This PR adds a buildspec to run the scanner in CodeBuild CI job.

### Proposed changes:
* Add CodeBuild buildspec to run SonarQube scanner

<!-- Add detailed discussion of changes here -->

### Security implications
<!-- What are the potential security concerns? Does the change deal with PII? User input? A component with a known vulnerability? Etc. -->
N/A

### Acceptance criteria validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? If not, why not? -->
**CI job successfully completed:**
https://us-east-1.console.aws.amazon.com/codesuite/codebuild/968524040713/projects/qpp-eu-data-ci/build/qpp-eu-data-ci%3A36895fe5-ee30-471e-b337-b7a88c2d92ea/?region=us-east-1

**Scanner analysis successfully uploaded to SonarQube host:**
https://sonarqube.cloud.cms.gov/dashboard?id=qpp-eu-data&branch=cp%2FQPPELIG-4460

### Requested feedback
<!-- What type of feedback would you like from reviewers? -->

<!-- Insert screenshots if needed (drag images here) -->
